### PR TITLE
Implement labels for semantic versioning

### DIFF
--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/App.scala
@@ -66,35 +66,35 @@ sealed trait LagomApp extends App {
 case object LagomJavaApp extends LagomApp {
   override def projectSettings: Seq[Setting[_]] =
     super.projectSettings ++ Vector(
-      reactiveLibProject := magic.Lagom.version.map(v => s"reactive-lib-lagom${formatVersionMajorMinor(v)}-java")
+      reactiveLibProject := magic.Lagom.version.map(v => s"reactive-lib-lagom${SemVer.formatMajorMinor(v)}-java")
     )
 }
 
 case object LagomScalaApp extends LagomApp {
   override def projectSettings: Seq[Setting[_]] =
     super.projectSettings ++ Vector(
-      reactiveLibProject := magic.Lagom.version.map(v => s"reactive-lib-lagom${formatVersionMajorMinor(v)}-scala")
+      reactiveLibProject := magic.Lagom.version.map(v => s"reactive-lib-lagom${SemVer.formatMajorMinor(v)}-scala")
     )
 }
 
 case object LagomPlayJavaApp extends LagomApp {
   override def projectSettings: Seq[Setting[_]] =
     super.projectSettings ++ Vector(
-      reactiveLibProject := magic.Lagom.version.map(v => s"reactive-lib-lagom${formatVersionMajorMinor(v)}-java")
+      reactiveLibProject := magic.Lagom.version.map(v => s"reactive-lib-lagom${SemVer.formatMajorMinor(v)}-java")
     )
 }
 
 case object LagomPlayScalaApp extends LagomApp {
   override def projectSettings: Seq[Setting[_]] =
     super.projectSettings ++ Vector(
-      reactiveLibProject := magic.Lagom.version.map(v => s"reactive-lib-lagom${formatVersionMajorMinor(v)}-scala")
+      reactiveLibProject := magic.Lagom.version.map(v => s"reactive-lib-lagom${SemVer.formatMajorMinor(v)}-scala")
     )
 }
 
 case object PlayApp extends App {
   override def projectSettings: Seq[Setting[_]] =
     super.projectSettings ++ Vector(
-      reactiveLibProject := magic.Play.version.map(v => s"reactive-lib-play${formatVersionMajorMinor(v)}")
+      reactiveLibProject := magic.Play.version.map(v => s"reactive-lib-play${SemVer.formatMajorMinor(v)}")
     )
 }
 
@@ -116,6 +116,30 @@ object App {
       BasicApp
 }
 
-private object formatVersionMajorMinor {
-  def apply(version: String): String = version.filterNot(_ == '.').take(2)
+private object SemVer {
+  def formatMajorMinor(version: String): String = version.filterNot(_ == '.').take(2)
+
+  def parse(version: String): Option[(Int, Int, Int, Option[String])] = {
+    val parts = version.split("\\.", 3)
+
+    if (
+      parts.length == 3 &&
+        parts(0).forall(_.isDigit) &&
+        parts(1).forall(_.isDigit) &&
+        parts(2).takeWhile(_ != '-').forall(_.isDigit)) {
+      val major = parts(0).toInt
+      val minor = parts(1).toInt
+      val patchParts = parts(2).split("-", 2)
+
+      val (patch, label) =
+        if (patchParts.length == 2)
+          (patchParts(0).toInt, Some(patchParts(1)))
+        else
+          (parts(2).toInt, None)
+
+      Some((major, minor, patch, label))
+    } else {
+      None
+    }
+  }
 }

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveApp.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveApp.scala
@@ -16,7 +16,6 @@
 
 package com.lightbend.rp.sbtreactiveapp
 
-import play.api.libs.json._
 import SbtReactiveAppPlugin.autoImport._
 import scala.collection.immutable.Seq
 
@@ -29,7 +28,8 @@ object SbtReactiveApp {
              privileged: Boolean,
              healthCheck: Option[Check],
              readinessCheck: Option[Check],
-             environmentVariables: Map[String, EnvironmentVariable]): Map[String, String] = {
+             environmentVariables: Map[String, EnvironmentVariable],
+             version: Option[(Int, Int, Int, Option[String])]): Map[String, String] = {
     def ns(key: String*): String = (Seq("com", "lightbend", "rp") ++ key).mkString(".")
 
     val keyValuePairs =
@@ -131,6 +131,15 @@ object SbtReactiveApp {
                 ns(s"environment-variables", i.toString, "key") -> key
               )
           }
+        } ++
+      version
+        .toSeq
+        .flatMap { case (major, minor, patch, maybeLabel) =>
+          Vector(
+            ns("version-major") -> major.toString,
+            ns("version-minor") -> minor.toString,
+            ns("version-patch") -> patch.toString) ++
+          maybeLabel.toVector.map(label => ns("version-patch-label") -> label)
         }
 
     keyValuePairs.toMap

--- a/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
+++ b/src/main/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppPlugin.scala
@@ -82,7 +82,8 @@ object SbtReactiveAppPlugin extends AutoPlugin {
             privileged = privileged.value,
             healthCheck = healthCheck.value,
             readinessCheck = readinessCheck.value,
-            environmentVariables = environmentVariables.value
+            environmentVariables = environmentVariables.value,
+            version = SemVer.parse(Keys.version.value)
           )
           .map { case (key, value) =>
             docker.Cmd("LABEL", s"""$key="${encodeLabelValue(value)}"""")

--- a/src/sbt-test/sbt-reactive-app/labels/build.sbt
+++ b/src/sbt-test/sbt-reactive-app/labels/build.sbt
@@ -1,4 +1,4 @@
-version := "0.1"
+version := "0.1.2-SNAPSHOT"
 scalaVersion := "2.12.3"
 
 enablePlugins(DockerPlugin)
@@ -49,7 +49,11 @@ TaskKey[Unit]("check") := {
     """LABEL com.lightbend.rp.volumes.0.type="host-path"""",
     """LABEL com.lightbend.rp.volumes.1.guest-path="/data2"""",
     """LABEL com.lightbend.rp.volumes.1.secret="my-secret"""",
-    """LABEL com.lightbend.rp.volumes.1.type="secret"""")
+    """LABEL com.lightbend.rp.volumes.1.type="secret"""",
+    """LABEL com.lightbend.rp.version-major="0"""",
+    """LABEL com.lightbend.rp.version-minor="1"""",
+    """LABEL com.lightbend.rp.version-patch="2"""",
+    """LABEL com.lightbend.rp.version-patch-label="SNAPSHOT"""")
 
   lines.foreach { line =>
     if (!contents.contains(line)) {

--- a/src/test/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppSpec.scala
+++ b/src/test/scala/com/lightbend/rp/sbtreactiveapp/SbtReactiveAppSpec.scala
@@ -28,7 +28,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         privileged = false,
         healthCheck = None,
         readinessCheck = None,
-        environmentVariables = Map.empty) shouldBe Map.empty
+        environmentVariables = Map.empty,
+        version = None) shouldBe Map.empty
     }
 
     "work for all values (except checks)" in {
@@ -52,7 +53,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         environmentVariables = Map(
           "env1" -> LiteralEnvironmentVariable("my env one"),
           "env2" -> SecretEnvironmentVariable("my-secret"),
-          "env3" -> kubernetes.ConfigMapEnvironmentVariable("my-map", "my-key"))) shouldBe Map(
+          "env3" -> kubernetes.ConfigMapEnvironmentVariable("my-map", "my-key")),
+        version = Some((1, 2, 3, Some("SNAPSHOT")))) shouldBe Map(
 
         "com.lightbend.rp.disk-space" -> "1234",
         "com.lightbend.rp.memory" -> "5678",
@@ -99,7 +101,11 @@ class SbtReactiveAppSpec extends UnitSpec {
         "com.lightbend.rp.environment-variables.2.name" -> "env3",
         "com.lightbend.rp.environment-variables.2.type" -> "configMap",
         "com.lightbend.rp.environment-variables.2.map-name" -> "my-map",
-        "com.lightbend.rp.environment-variables.2.key" -> "my-key")
+        "com.lightbend.rp.environment-variables.2.key" -> "my-key",
+        "com.lightbend.rp.version-major" -> "1",
+        "com.lightbend.rp.version-minor" -> "2",
+        "com.lightbend.rp.version-patch" -> "3",
+        "com.lightbend.rp.version-patch-label" -> "SNAPSHOT")
     }
 
     "work for tcp checks" in {
@@ -112,7 +118,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         privileged = false,
         healthCheck = Some(TcpCheck(80, 10)),
         readinessCheck = Some(TcpCheck(90, 5)),
-        environmentVariables = Map.empty) shouldBe Map(
+        environmentVariables = Map.empty,
+        version = None) shouldBe Map(
           "com.lightbend.rp.health-check.type" -> "tcp",
           "com.lightbend.rp.health-check.port" -> "80",
           "com.lightbend.rp.health-check.interval" -> "10",
@@ -129,7 +136,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         privileged = false,
         healthCheck = Some(TcpCheck("test", 10)),
         readinessCheck = Some(TcpCheck("test2", 5)),
-        environmentVariables = Map.empty) shouldBe Map(
+        environmentVariables = Map.empty,
+        version = None) shouldBe Map(
           "com.lightbend.rp.health-check.type" -> "tcp",
           "com.lightbend.rp.health-check.service-name" -> "test",
           "com.lightbend.rp.health-check.interval" -> "10",
@@ -148,7 +156,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         privileged = false,
         healthCheck = Some(HttpCheck(80, 10, "/health")),
         readinessCheck = Some(HttpCheck(90, 5, "/other-health")),
-        environmentVariables = Map.empty) shouldBe Map(
+        environmentVariables = Map.empty,
+        version = None) shouldBe Map(
         "com.lightbend.rp.health-check.type" -> "http",
         "com.lightbend.rp.health-check.port" -> "80",
         "com.lightbend.rp.health-check.interval" -> "10",
@@ -167,7 +176,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         privileged = false,
         healthCheck = Some(HttpCheck("test", 10, "/health")),
         readinessCheck = Some(HttpCheck("test2", 5, "/other-health")),
-        environmentVariables = Map.empty) shouldBe Map(
+        environmentVariables = Map.empty,
+        version = None) shouldBe Map(
         "com.lightbend.rp.health-check.type" -> "http",
         "com.lightbend.rp.health-check.service-name" -> "test",
         "com.lightbend.rp.health-check.interval" -> "10",
@@ -188,7 +198,8 @@ class SbtReactiveAppSpec extends UnitSpec {
         privileged = false,
         healthCheck = Some(CommandCheck("/bin/bash", "arg one", "arg two")),
         readinessCheck = Some(CommandCheck("/bin/ash", "arg 1", "arg 2")),
-        environmentVariables = Map.empty) shouldBe Map(
+        environmentVariables = Map.empty,
+        version = None) shouldBe Map(
         "com.lightbend.rp.health-check.type" -> "command",
         "com.lightbend.rp.health-check.args.0" -> "/bin/bash",
         "com.lightbend.rp.health-check.args.1" -> "arg one",

--- a/src/test/scala/com/lightbend/rp/sbtreactiveapp/SemVerSpec.scala
+++ b/src/test/scala/com/lightbend/rp/sbtreactiveapp/SemVerSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lightbend.rp.sbtreactiveapp
+
+class SemVerSpec extends UnitSpec {
+  "formatMajorMinor" should {
+    "work" in {
+      SemVer.formatMajorMinor("1.0.0") shouldEqual "10"
+      SemVer.formatMajorMinor("1.0.1") shouldEqual "10"
+      SemVer.formatMajorMinor("3.2.3") shouldEqual "32"
+    }
+  }
+
+  "parse" should {
+    "correctly parse a semantic version number" in {
+      SemVer.parse("1.2.3") shouldEqual Some((1, 2, 3, None))
+      SemVer.parse("1.2.3-SNAPSHOT") shouldEqual Some((1, 2, 3, Some("SNAPSHOT")))
+    }
+
+    "fail to parse a non-semantic version number" in {
+      SemVer.parse("abc.xyz.123") shouldEqual None
+    }
+  }
+}


### PR DESCRIPTION
This PR implements labels for semantic versioning, so that when a project version is specified as semantic, the proper labels are generated.

e.g. `1.2.3-SNAPSHOT` results in a Dockerfile with:

```
LABEL com.lightbend.rp.version-major 1
LABEL com.lightbend.rp.version-minor 2
LABEL com.lightbend.rp.version-patch 3
LABEL com.lightbend.rp.version-patch-label SNAPSHOT
```

Fixes #6